### PR TITLE
Fix typo in the documentation

### DIFF
--- a/lib/parsetools/doc/src/yecc.xml
+++ b/lib/parsetools/doc/src/yecc.xml
@@ -335,7 +335,7 @@ element -> list : '$1'.    </code>
       <c>(a b c).</c>. This still assumes that this was the first
       input line that the scanner tokenized:</p>
     <code type="none">
-{cons, {atom, 1, a,} {cons, {atom, 1, b},
+{cons, {atom, 1, a}, {cons, {atom, 1, b},
                             {cons, {atom, 1, c}, nil}}}    </code>
     <p>The associated code contains <c>pseudo variables</c> <c>'$1'</c>, <c>'$2'</c>, <c>'$3'</c>, etc. which refer to (are
       bound to) the values associated previously by the parser with

--- a/lib/parsetools/doc/src/yecc.xml
+++ b/lib/parsetools/doc/src/yecc.xml
@@ -335,7 +335,7 @@ element -> list : '$1'.    </code>
       <c>(a b c).</c>. This still assumes that this was the first
       input line that the scanner tokenized:</p>
     <code type="none">
-{cons, {atom, 1, a}, {cons, {atom, 1, b},
+{cons, {atom, 1, a}, {cons, {atom, 1, b}, 
                             {cons, {atom, 1, c}, nil}}}    </code>
     <p>The associated code contains <c>pseudo variables</c> <c>'$1'</c>, <c>'$2'</c>, <c>'$3'</c>, etc. which refer to (are
       bound to) the values associated previously by the parser with

--- a/lib/stdlib/doc/src/re.xml
+++ b/lib/stdlib/doc/src/re.xml
@@ -2445,6 +2445,24 @@ foo\Kbar</code>
     </list>
 
     <p>However, escaping other non-alphanumeric characters does no harm.</p>
+	
+	<p>Character classes have ability to use union, intersection and subtraction.</p>
+	
+	<p>The union of the character class allows to match a character from one of 
+	  the specified ranges i.e. the expression  [a-f[A-F[0-9]]] matches a single 
+	  character which is either a small alphabet set (a-f), a big alphabet set 
+	  (A-F) or a digit (0-9).</p> 
+	  
+	<p>An intersection relation between ranges is defined using <c>&&</c>. The syntax 
+	  for it is <c>[class&&[intersect]]</c>. You can use the full character class syntax within 
+	  the intersected character classes. The expression [\\w&&[a-fA-F0-9\\s]] matches 
+	  a single hex-character.</p>
+    
+	<p>Character class subtraction makes it easy to match a character that is in a certain 
+	  list, but not in another list. E.g. [a-z-[aeiou]] matches an English consonant. 
+	  It is particularly handy when working with Unicode properties. E.g. [\\p{Thai}-[\\P{N}]] 
+	  matches any Thai numbers.</p>
+	  
   </section>
 
   <section>

--- a/lib/stdlib/doc/src/re.xml
+++ b/lib/stdlib/doc/src/re.xml
@@ -2456,7 +2456,7 @@ foo\Kbar</code>
 	<p>An intersection relation between ranges is defined using <c>&&</c>. The syntax 
 	  for it is <c>[class&&[intersect]]</c>. You can use the full character class syntax within 
 	  the intersected character classes. The expression [\\w&&[a-fA-F0-9\\s]] matches 
-	  a single hex-character.</p>
+	  a single character.</p>
     
 	<p>Character class subtraction makes it easy to match a character that is in a certain 
 	  list, but not in another list. E.g. [a-z-[aeiou]] matches an English consonant. 


### PR DESCRIPTION
Fix type in the code example